### PR TITLE
Fix minutes display when 0 through 9

### DIFF
--- a/src/time-me.coffee
+++ b/src/time-me.coffee
@@ -81,11 +81,14 @@ relativeToNoon = (hours) ->
     "PM"
   else
     "AM"
+    
+padTimeDigits = (number) ->
+  ("00" + number).substr(-2,2)
 
 formattedUnixTime = (timestamp) ->
   date = new Date(parseInt(timestamp) * 1000)
   console.log date
-  "#{dayNames[date.getUTCDay()]}, #{monthNames[date.getUTCMonth()]} #{date.getUTCDate()} at #{date.getUTCHours()}:#{date.getUTCMinutes()} #{relativeToNoon(date.getUTCHours())}."
+  "#{dayNames[date.getUTCDay()]}, #{monthNames[date.getUTCMonth()]} #{date.getUTCDate()} at #{date.getUTCHours()}:#{padTimeDigits(date.getUTCMinutes())} #{relativeToNoon(date.getUTCHours())}."
 
 timeAtLatitudeAndLongitude = (robot, location, cb) ->
   robot.http("http://api.timezonedb.com/").query


### PR DESCRIPTION
Noticed that minutes 0-9 would not have a leading zero. For example, 3:07 PM would show up as 3:7 PM. This change zero pads the number.
